### PR TITLE
Add ingestion pipeline, daemon mode, and CLI

### DIFF
--- a/src/arcana/cli.py
+++ b/src/arcana/cli.py
@@ -1,0 +1,190 @@
+"""Arcana CLI — command-line interface for the ingestion pipeline."""
+
+import logging
+import sys
+from datetime import datetime, timezone
+
+import click
+
+from arcana.config import ArcanaConfig, DatabaseConfig
+from arcana.ingestion.coinbase import CoinbaseSource
+from arcana.pipeline import DAEMON_INTERVAL, ingest_backfill, run_daemon
+from arcana.storage.database import Database
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        stream=sys.stderr,
+    )
+
+
+@click.group()
+@click.option("-v", "--verbose", is_flag=True, help="Enable debug logging.")
+def cli(verbose: bool) -> None:
+    """Arcana — Quantitative trading data pipeline."""
+    _setup_logging(verbose)
+
+
+# --- Database commands ---
+
+
+@cli.group()
+def db() -> None:
+    """Database management commands."""
+    pass
+
+
+@db.command("init")
+@click.option("--host", default="localhost", help="Database host.")
+@click.option("--port", default=5432, type=int, help="Database port.")
+@click.option("--database", default="arcana", help="Database name.")
+@click.option("--user", default="arcana", help="Database user.")
+@click.option("--password", default="", help="Database password.")
+def db_init(host: str, port: int, database: str, user: str, password: str) -> None:
+    """Initialize database schema (creates tables if they don't exist)."""
+    config = DatabaseConfig(
+        host=host, port=port, database=database, user=user, password=password
+    )
+    try:
+        with Database(config) as db:
+            db.init_schema()
+        click.echo("Database schema initialized successfully.")
+    except Exception as exc:
+        click.echo(f"Failed to initialize database: {exc}", err=True)
+        raise SystemExit(1)
+
+
+# --- Ingestion commands ---
+
+
+@cli.command()
+@click.argument("pair")
+@click.option(
+    "--since",
+    required=True,
+    type=click.DateTime(formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S"]),
+    help="Start date for backfill (e.g. 2025-01-01).",
+)
+@click.option("--host", default="localhost", help="Database host.")
+@click.option("--port", default=5432, type=int, help="Database port.")
+@click.option("--database", default="arcana", help="Database name.")
+@click.option("--user", default="arcana", help="Database user.")
+@click.option("--password", default="", help="Database password.")
+def ingest(
+    pair: str,
+    since: datetime,
+    host: str,
+    port: int,
+    database: str,
+    user: str,
+    password: str,
+) -> None:
+    """Bulk ingest historical trades for a trading pair.
+
+    Example: arcana ingest ETH-USD --since 2025-01-01
+    """
+    since_utc = since.replace(tzinfo=timezone.utc)
+    config = DatabaseConfig(
+        host=host, port=port, database=database, user=user, password=password
+    )
+
+    click.echo(f"Ingesting {pair} from {since_utc.date()} to now...")
+
+    with CoinbaseSource() as source, Database(config) as db_conn:
+        db_conn.init_schema()
+        total = ingest_backfill(source, db_conn, pair, since=since_utc)
+
+    click.echo(f"Done. {total} new trades ingested.")
+
+
+# --- Daemon command ---
+
+
+@cli.command()
+@click.argument("pair")
+@click.option(
+    "--interval",
+    default=DAEMON_INTERVAL,
+    type=int,
+    help="Poll interval in seconds (default: 900 = 15 min).",
+)
+@click.option("--host", default="localhost", help="Database host.")
+@click.option("--port", default=5432, type=int, help="Database port.")
+@click.option("--database", default="arcana", help="Database name.")
+@click.option("--user", default="arcana", help="Database user.")
+@click.option("--password", default="", help="Database password.")
+def run(
+    pair: str,
+    interval: int,
+    host: str,
+    port: int,
+    database: str,
+    user: str,
+    password: str,
+) -> None:
+    """Run the ingestion daemon for a trading pair.
+
+    Polls Coinbase for new trades every --interval seconds.
+    Catches up any missed trades on startup.
+
+    Example: arcana run ETH-USD
+    """
+    config = DatabaseConfig(
+        host=host, port=port, database=database, user=user, password=password
+    )
+
+    click.echo(f"Starting daemon for {pair} (poll every {interval}s)...")
+    click.echo("Press Ctrl+C to stop.")
+
+    with CoinbaseSource() as source, Database(config) as db_conn:
+        run_daemon(source, db_conn, pair, interval=interval)
+
+    click.echo("Daemon stopped.")
+
+
+# --- Status command ---
+
+
+@cli.command()
+@click.argument("pair", required=False)
+@click.option("--host", default="localhost", help="Database host.")
+@click.option("--port", default=5432, type=int, help="Database port.")
+@click.option("--database", default="arcana", help="Database name.")
+@click.option("--user", default="arcana", help="Database user.")
+@click.option("--password", default="", help="Database password.")
+def status(
+    pair: str | None,
+    host: str,
+    port: int,
+    database: str,
+    user: str,
+    password: str,
+) -> None:
+    """Show ingestion status and trade counts.
+
+    Example: arcana status ETH-USD
+    """
+    config = DatabaseConfig(
+        host=host, port=port, database=database, user=user, password=password
+    )
+
+    try:
+        with Database(config) as db_conn:
+            total = db_conn.get_trade_count(pair)
+            last_ts = db_conn.get_last_timestamp(pair or "ETH-USD")
+
+            click.echo(f"{'Pair: ' + pair if pair else 'All pairs'}")
+            click.echo(f"  Total trades: {total:,}")
+            if last_ts:
+                click.echo(f"  Last trade:   {last_ts.isoformat()}")
+                gap = datetime.now(timezone.utc) - last_ts
+                click.echo(f"  Data gap:     {gap}")
+            else:
+                click.echo("  No trades stored yet.")
+    except Exception as exc:
+        click.echo(f"Failed to connect: {exc}", err=True)
+        raise SystemExit(1)

--- a/src/arcana/pipeline.py
+++ b/src/arcana/pipeline.py
@@ -1,0 +1,242 @@
+"""Ingestion pipeline — bulk backfill and daemon mode.
+
+This module orchestrates fetching trades from a DataSource and storing
+them in the database, with checkpointing, progress logging, and
+graceful shutdown support.
+"""
+
+import logging
+import signal
+import time as time_mod
+from datetime import datetime, timedelta, timezone
+
+from arcana.ingestion.base import DataSource
+from arcana.ingestion.models import Trade
+from arcana.storage.database import Database
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 1000  # Trades per DB commit
+DEFAULT_WINDOW = timedelta(hours=1)
+DAEMON_INTERVAL = 15 * 60  # 15 minutes in seconds
+
+
+class GracefulShutdown:
+    """Catches SIGINT/SIGTERM and sets a flag for clean exit."""
+
+    def __init__(self) -> None:
+        self.should_stop = False
+        signal.signal(signal.SIGINT, self._handle)
+        signal.signal(signal.SIGTERM, self._handle)
+
+    def _handle(self, signum: int, frame: object) -> None:
+        sig_name = signal.Signals(signum).name
+        logger.info("Received %s — finishing current batch before shutdown...", sig_name)
+        self.should_stop = True
+
+
+def ingest_backfill(
+    source: DataSource,
+    db: Database,
+    pair: str,
+    since: datetime,
+    window: timedelta = DEFAULT_WINDOW,
+) -> int:
+    """Bulk backfill trades from `since` to now.
+
+    Walks forward through time in windows, committing each batch
+    to the database. Resumable — on restart, starts from the last
+    stored timestamp.
+
+    Args:
+        source: Data source to fetch from.
+        db: Database to store trades in.
+        pair: Trading pair, e.g. 'ETH-USD'.
+        since: Start date for backfill.
+        window: Size of each time window to query.
+
+    Returns:
+        Total number of new trades inserted.
+    """
+    shutdown = GracefulShutdown()
+
+    # Resume from last stored trade if any
+    last_ts = db.get_last_timestamp(pair, source.name)
+    if last_ts and last_ts > since:
+        logger.info("Resuming from %s (found existing data)", last_ts.isoformat())
+        since = last_ts
+
+    end = datetime.now(timezone.utc)
+    total_windows = max(1, int((end - since) / window) + 1)
+    current = since
+    window_num = 0
+    total_inserted = 0
+    batch_buffer: list[Trade] = []
+    start_time = time_mod.time()
+
+    logger.info(
+        "Starting backfill: %s %s from %s to %s (~%d windows)",
+        source.name,
+        pair,
+        since.strftime("%Y-%m-%d %H:%M"),
+        end.strftime("%Y-%m-%d %H:%M"),
+        total_windows,
+    )
+
+    while current < end:
+        if shutdown.should_stop:
+            logger.info("Shutdown requested — committing remaining buffer...")
+            if batch_buffer:
+                total_inserted += db.insert_trades(batch_buffer)
+                batch_buffer.clear()
+            break
+
+        window_end = min(current + window, end)
+        window_num += 1
+
+        try:
+            trades = source.fetch_trades(pair=pair, start=current, end=window_end)
+        except Exception:
+            logger.exception(
+                "Failed to fetch window %d (%s → %s). Halting backfill.",
+                window_num,
+                current.isoformat(),
+                window_end.isoformat(),
+            )
+            # Commit what we have before stopping
+            if batch_buffer:
+                total_inserted += db.insert_trades(batch_buffer)
+            raise
+
+        batch_buffer.extend(trades)
+
+        # Checkpoint: commit when buffer reaches BATCH_SIZE
+        if len(batch_buffer) >= BATCH_SIZE:
+            inserted = db.insert_trades(batch_buffer)
+            total_inserted += inserted
+            batch_buffer.clear()
+
+        # Progress logging
+        elapsed = time_mod.time() - start_time
+        rate = total_inserted / elapsed if elapsed > 0 else 0
+        remaining_windows = total_windows - window_num
+        eta_seconds = remaining_windows / (window_num / elapsed) if window_num > 0 else 0
+
+        logger.info(
+            "Window %d/%d | %s → %s | %d trades this window | "
+            "Total: %d stored | %.1f trades/sec | ETA: %s",
+            window_num,
+            total_windows,
+            current.strftime("%Y-%m-%d %H:%M"),
+            window_end.strftime("%Y-%m-%d %H:%M"),
+            len(trades),
+            total_inserted + len(batch_buffer),
+            rate,
+            _format_eta(eta_seconds),
+        )
+
+        current = window_end
+        time_mod.sleep(0.12)  # rate limit
+
+    # Final flush
+    if batch_buffer:
+        total_inserted += db.insert_trades(batch_buffer)
+
+    elapsed = time_mod.time() - start_time
+    logger.info(
+        "Backfill complete: %d trades inserted in %s",
+        total_inserted,
+        _format_eta(elapsed),
+    )
+    return total_inserted
+
+
+def run_daemon(
+    source: DataSource,
+    db: Database,
+    pair: str,
+    interval: int = DAEMON_INTERVAL,
+) -> None:
+    """Run the ingestion daemon — poll for new trades on a timer.
+
+    On startup, detects last stored timestamp and catches up any gap.
+    Then enters a poll loop, fetching new trades every `interval` seconds.
+
+    Args:
+        source: Data source to fetch from.
+        db: Database to store trades in.
+        pair: Trading pair, e.g. 'ETH-USD'.
+        interval: Seconds between poll cycles.
+    """
+    shutdown = GracefulShutdown()
+
+    last_ts = db.get_last_timestamp(pair, source.name)
+    if last_ts is None:
+        logger.error(
+            "No data found for %s. Run 'arcana ingest %s --since <date>' first.",
+            pair,
+            pair,
+        )
+        return
+
+    logger.info(
+        "Daemon starting for %s %s | Last trade: %s | Poll interval: %ds",
+        source.name,
+        pair,
+        last_ts.isoformat(),
+        interval,
+    )
+
+    # Catch-up phase: fill gap from last stored trade to now
+    gap = datetime.now(timezone.utc) - last_ts
+    if gap.total_seconds() > interval:
+        logger.info("Catching up: %s gap detected", _format_eta(gap.total_seconds()))
+        ingest_backfill(source, db, pair, since=last_ts)
+        last_ts = db.get_last_timestamp(pair, source.name) or last_ts
+
+    # Poll loop
+    cycle = 0
+    while not shutdown.should_stop:
+        cycle += 1
+        now = datetime.now(timezone.utc)
+
+        try:
+            trades = source.fetch_trades(pair=pair, start=last_ts, end=now)
+            if trades:
+                inserted = db.insert_trades(trades)
+                new_last = db.get_last_timestamp(pair, source.name)
+                logger.info(
+                    "Cycle %d | %d trades fetched, %d new | Last: %s",
+                    cycle,
+                    len(trades),
+                    inserted,
+                    new_last.isoformat() if new_last else "?",
+                )
+                if new_last:
+                    last_ts = new_last
+            else:
+                logger.info("Cycle %d | No new trades", cycle)
+
+        except Exception:
+            logger.exception("Cycle %d failed. Will retry next cycle.", cycle)
+
+        # Sleep in small increments so we can respond to shutdown quickly
+        for _ in range(interval):
+            if shutdown.should_stop:
+                break
+            time_mod.sleep(1)
+
+    total = db.get_trade_count(pair)
+    logger.info("Daemon stopped. Total trades for %s: %d", pair, total)
+
+
+def _format_eta(seconds: float) -> str:
+    """Format seconds into a human-readable string."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    elif seconds < 3600:
+        return f"{seconds / 60:.1f}m"
+    else:
+        hours = int(seconds // 3600)
+        minutes = int((seconds % 3600) // 60)
+        return f"{hours}h {minutes}m"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,68 @@
+"""Tests for the CLI interface."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from arcana.cli import cli
+
+
+class TestCLI:
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "Arcana" in result.output
+
+    def test_db_init_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["db", "init", "--help"])
+        assert result.exit_code == 0
+        assert "--host" in result.output
+
+    def test_ingest_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ingest", "--help"])
+        assert result.exit_code == 0
+        assert "--since" in result.output
+        assert "PAIR" in result.output
+
+    def test_run_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run", "--help"])
+        assert result.exit_code == 0
+        assert "--interval" in result.output
+
+    def test_status_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["status", "--help"])
+        assert result.exit_code == 0
+
+    @patch("arcana.cli.Database")
+    @patch("arcana.cli.CoinbaseSource")
+    @patch("arcana.cli.ingest_backfill")
+    def test_ingest_command(self, mock_backfill, mock_source_cls, mock_db_cls):
+        mock_backfill.return_value = 42
+
+        # Configure context managers
+        mock_source = MagicMock()
+        mock_source_cls.return_value.__enter__ = MagicMock(return_value=mock_source)
+        mock_source_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_db = MagicMock()
+        mock_db_cls.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_db_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ingest", "ETH-USD", "--since", "2025-01-01"])
+
+        assert result.exit_code == 0
+        assert "42 new trades ingested" in result.output
+        mock_backfill.assert_called_once()
+        mock_db.init_schema.assert_called_once()
+
+    def test_ingest_requires_since(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ingest", "ETH-USD"])
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,151 @@
+"""Tests for the ingestion pipeline."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from arcana.ingestion.coinbase import CoinbaseSource
+from arcana.ingestion.models import Trade
+from arcana.pipeline import BATCH_SIZE, _format_eta, ingest_backfill
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _make_trades(count: int, start_ts: datetime | None = None) -> list[Trade]:
+    """Generate a list of fake trades for testing."""
+    base = start_ts or datetime(2026, 2, 10, 12, 0, 0, tzinfo=timezone.utc)
+    trades = []
+    for i in range(count):
+        trades.append(
+            Trade(
+                timestamp=base + timedelta(seconds=i),
+                trade_id=f"test-{i:06d}",
+                source="coinbase",
+                pair="ETH-USD",
+                price=Decimal("2845.50"),
+                size=Decimal("0.1"),
+                side="buy" if i % 2 == 0 else "sell",
+            )
+        )
+    return trades
+
+
+class TestIngestBackfill:
+    @patch("arcana.pipeline.GracefulShutdown")
+    @patch("arcana.pipeline.time_mod.sleep")
+    def test_backfill_stores_trades(self, mock_sleep, mock_shutdown):
+        """Backfill should fetch trades and store them in the database."""
+        mock_shutdown.return_value.should_stop = False
+        trades = _make_trades(10)
+
+        source = MagicMock(spec=CoinbaseSource)
+        source.name = "coinbase"
+        source.fetch_trades.return_value = trades
+        source._client = True  # just needs to be truthy
+
+        db = MagicMock()
+        db.get_last_timestamp.return_value = None
+        db.insert_trades.return_value = 10
+
+        since = datetime(2026, 2, 10, 12, 0, 0, tzinfo=timezone.utc)
+        total = ingest_backfill(source, db, "ETH-USD", since)
+
+        assert total == 10
+        assert db.insert_trades.called
+        assert source.fetch_trades.called
+
+    @patch("arcana.pipeline.GracefulShutdown")
+    @patch("arcana.pipeline.time_mod.sleep")
+    def test_backfill_resumes_from_last_timestamp(self, mock_sleep, mock_shutdown):
+        """If data exists, backfill should resume from last stored timestamp."""
+        mock_shutdown.return_value.should_stop = False
+
+        source = MagicMock(spec=CoinbaseSource)
+        source.name = "coinbase"
+        source.fetch_trades.return_value = []
+        source._client = True
+
+        last = datetime(2026, 2, 10, 14, 0, 0, tzinfo=timezone.utc)
+        db = MagicMock()
+        db.get_last_timestamp.return_value = last
+        db.insert_trades.return_value = 0
+
+        since = datetime(2026, 2, 10, 12, 0, 0, tzinfo=timezone.utc)
+        ingest_backfill(source, db, "ETH-USD", since)
+
+        # The first fetch_trades call should start from last, not since
+        first_call = source.fetch_trades.call_args_list[0]
+        assert first_call.kwargs["start"] == last
+
+    @patch("arcana.pipeline.GracefulShutdown")
+    @patch("arcana.pipeline.time_mod.sleep")
+    def test_backfill_checkpoints_in_batches(self, mock_sleep, mock_shutdown):
+        """Trades should be committed in batches of BATCH_SIZE."""
+        mock_shutdown.return_value.should_stop = False
+
+        # Return enough trades to trigger at least one checkpoint
+        trades = _make_trades(600)
+
+        source = MagicMock(spec=CoinbaseSource)
+        source.name = "coinbase"
+        source.fetch_trades.return_value = trades
+        source._client = True
+
+        db = MagicMock()
+        db.get_last_timestamp.return_value = None
+        db.insert_trades.return_value = 600
+
+        since = datetime(2026, 2, 10, 12, 0, 0, tzinfo=timezone.utc)
+        ingest_backfill(source, db, "ETH-USD", since, window=timedelta(minutes=30))
+
+        # insert_trades should be called (at least once for final flush)
+        assert db.insert_trades.called
+
+    @patch("arcana.pipeline.GracefulShutdown")
+    @patch("arcana.pipeline.time_mod.sleep")
+    def test_backfill_graceful_shutdown(self, mock_sleep, mock_shutdown):
+        """On shutdown signal, should commit buffer and stop."""
+        shutdown_instance = MagicMock()
+        # Stop after first window
+        shutdown_instance.should_stop = False
+
+        call_count = 0
+
+        def toggle_shutdown(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 1:
+                shutdown_instance.should_stop = True
+            return _make_trades(5)
+
+        mock_shutdown.return_value = shutdown_instance
+
+        source = MagicMock(spec=CoinbaseSource)
+        source.name = "coinbase"
+        source.fetch_trades.side_effect = toggle_shutdown
+        source._client = True
+
+        db = MagicMock()
+        db.get_last_timestamp.return_value = None
+        db.insert_trades.return_value = 5
+
+        since = datetime(2026, 2, 10, 12, 0, 0, tzinfo=timezone.utc)
+        total = ingest_backfill(source, db, "ETH-USD", since)
+
+        # Should have committed the buffer before stopping
+        assert db.insert_trades.called
+
+
+class TestFormatEta:
+    def test_seconds(self):
+        assert _format_eta(45) == "45s"
+
+    def test_minutes(self):
+        assert _format_eta(150) == "2.5m"
+
+    def test_hours(self):
+        assert _format_eta(7500) == "2h 5m"


### PR DESCRIPTION
Pipeline (pipeline.py):
- ingest_backfill(): walks forward through 1-hour time windows, commits trades in batches of 1000, resumable from MAX(timestamp), progress logging with ETA, halts on persistent API failure
- run_daemon(): catches up any gap on startup, then polls every 15min, sleeps in 1s increments for responsive shutdown
- GracefulShutdown: catches SIGINT/SIGTERM, commits current batch

CLI (cli.py):
- arcana db init: create tables/hypertables
- arcana ingest ETH-USD --since 2025-01-01: bulk backfill
- arcana run ETH-USD: daemon mode
- arcana status [PAIR]: trade counts and data gap

31 tests passing (17 coinbase/model + 7 CLI + 7 pipeline).