### PR TITLE
Fix data gaps: add binary-subdivision pagination for complete trade i…

### DIFF
--- a/src/arcana/ingestion/base.py
+++ b/src/arcana/ingestion/base.py
@@ -25,6 +25,9 @@ class DataSource(ABC):
     ) -> list[Trade]:
         """Fetch trades for a given pair within an optional time window.
 
+        This is a single-request method — may not return all trades if the
+        source has a per-request limit.
+
         Args:
             pair: Trading pair, e.g. 'ETH-USD'.
             start: Inclusive start time (UTC). None means 'as early as possible'.
@@ -35,6 +38,27 @@ class DataSource(ABC):
             List of Trade objects, ordered by timestamp ascending.
         """
         ...
+
+    def fetch_all_trades(
+        self,
+        pair: str,
+        start: datetime,
+        end: datetime,
+    ) -> list[Trade]:
+        """Fetch ALL trades in a time window, handling pagination automatically.
+
+        Subclasses should override this if the source has per-request limits
+        that require multiple calls to retrieve complete data.
+
+        Args:
+            pair: Trading pair, e.g. 'ETH-USD'.
+            start: Start of time window (UTC).
+            end: End of time window (UTC).
+
+        Returns:
+            List of all Trade objects in the range, ascending by timestamp.
+        """
+        return self.fetch_trades(pair=pair, start=start, end=end)
 
     @abstractmethod
     def get_supported_pairs(self) -> list[str]:

--- a/src/arcana/pipeline.py
+++ b/src/arcana/pipeline.py
@@ -95,7 +95,7 @@ def ingest_backfill(
         window_num += 1
 
         try:
-            trades = source.fetch_trades(pair=pair, start=current, end=window_end)
+            trades = source.fetch_all_trades(pair=pair, start=current, end=window_end)
         except Exception:
             logger.exception(
                 "Failed to fetch window %d (%s → %s). Halting backfill.",
@@ -201,7 +201,7 @@ def run_daemon(
         now = datetime.now(timezone.utc)
 
         try:
-            trades = source.fetch_trades(pair=pair, start=last_ts, end=now)
+            trades = source.fetch_all_trades(pair=pair, start=last_ts, end=now)
             if trades:
                 inserted = db.insert_trades(trades)
                 new_last = db.get_last_timestamp(pair, source.name)

--- a/tests/test_ingestion/test_coinbase.py
+++ b/tests/test_ingestion/test_coinbase.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from arcana.ingestion.coinbase import CoinbaseSource
+from arcana.ingestion.coinbase import CoinbaseSource, DEFAULT_LIMIT
 
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 
@@ -24,6 +24,27 @@ def _mock_response(data: dict, status_code: int = 200) -> httpx.Response:
     resp.json.return_value = data
     resp.raise_for_status.return_value = None
     return resp
+
+
+def _make_raw_trades(
+    count: int,
+    start_time: str = "2026-02-10T14:00:00Z",
+    prefix: str = "test",
+) -> list[dict]:
+    """Generate raw API-format trade dicts for testing."""
+    base = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+    return [
+        {
+            "trade_id": f"{prefix}-{i:06d}",
+            "product_id": "ETH-USD",
+            "price": "2845.50",
+            "size": "0.1",
+            "time": (base + timedelta(seconds=i)).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+            "side": "BUY" if i % 2 == 0 else "SELL",
+            "exchange": "COINBASE",
+        }
+        for i in range(count)
+    ]
 
 
 class TestCoinbaseSource:
@@ -144,7 +165,7 @@ class TestCoinbaseSource:
 
         trades = source.fetch_trades_window("ETH-USD", start, end, window)
 
-        # 3 hours = 3 windows, each returns 20 trades
+        # 3 hours = 3 windows, each returns 20 trades (under limit, no subdivision)
         assert source._client.get.call_count == 3
         assert len(trades) == 60  # 20 * 3
         # All sorted ascending
@@ -171,3 +192,159 @@ class TestCoinbaseSource:
     def test_context_manager(self):
         with CoinbaseSource() as source:
             assert source.name == "coinbase"
+
+
+class TestFetchAllTrades:
+    """Tests for the binary-subdivision pagination logic."""
+
+    @patch("arcana.ingestion.coinbase.time_mod.sleep")
+    def test_no_subdivision_when_under_limit(self, mock_sleep):
+        """When API returns fewer than DEFAULT_LIMIT, no subdivision occurs."""
+        raw = _make_raw_trades(50)
+        source = CoinbaseSource()
+        source._client = MagicMock()
+        source._client.get.return_value = _mock_response({"trades": raw})
+
+        start = datetime(2026, 2, 10, 14, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 2, 10, 15, 0, 0, tzinfo=timezone.utc)
+
+        trades = source.fetch_all_trades("ETH-USD", start, end)
+
+        assert len(trades) == 50
+        assert source._client.get.call_count == 1  # single call, no subdivision
+
+    @patch("arcana.ingestion.coinbase.time_mod.sleep")
+    def test_subdivides_when_at_limit(self, mock_sleep):
+        """When API returns exactly DEFAULT_LIMIT, window is split in half."""
+        # First call: returns DEFAULT_LIMIT trades → triggers subdivision
+        full_batch = _make_raw_trades(DEFAULT_LIMIT, "2026-02-10T14:00:00Z", prefix="full")
+        # Left half: returns under limit → no further subdivision
+        left_batch = _make_raw_trades(100, "2026-02-10T14:00:00Z", prefix="left")
+        # Right half: returns under limit → no further subdivision
+        right_batch = _make_raw_trades(120, "2026-02-10T14:30:00Z", prefix="right")
+
+        source = CoinbaseSource()
+        source._client = MagicMock()
+        source._client.get.side_effect = [
+            _mock_response({"trades": full_batch}),
+            _mock_response({"trades": left_batch}),
+            _mock_response({"trades": right_batch}),
+        ]
+
+        start = datetime(2026, 2, 10, 14, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 2, 10, 15, 0, 0, tzinfo=timezone.utc)
+
+        trades = source.fetch_all_trades("ETH-USD", start, end)
+
+        # 3 API calls: initial full → left half → right half
+        assert source._client.get.call_count == 3
+        # Trades from both halves are merged (deduped by trade_id)
+        assert len(trades) == 220  # 100 + 120 (unique prefixes, no overlap)
+
+    @patch("arcana.ingestion.coinbase.time_mod.sleep")
+    def test_deduplicates_boundary_trades(self, mock_sleep):
+        """Trades appearing in both halves are deduplicated by trade_id."""
+        # Full batch → triggers subdivision
+        full_batch = _make_raw_trades(DEFAULT_LIMIT, prefix="full")
+        # Both halves share 10 trades at the boundary (same prefix = same trade_ids)
+        shared_trades = _make_raw_trades(10, "2026-02-10T14:29:50Z", prefix="shared")
+        left_unique = _make_raw_trades(80, "2026-02-10T14:00:00Z", prefix="left")
+        right_unique = _make_raw_trades(90, "2026-02-10T14:30:00Z", prefix="right")
+
+        source = CoinbaseSource()
+        source._client = MagicMock()
+        source._client.get.side_effect = [
+            _mock_response({"trades": full_batch}),
+            _mock_response({"trades": left_unique + shared_trades}),
+            _mock_response({"trades": shared_trades + right_unique}),
+        ]
+
+        start = datetime(2026, 2, 10, 14, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 2, 10, 15, 0, 0, tzinfo=timezone.utc)
+
+        trades = source.fetch_all_trades("ETH-USD", start, end)
+
+        # 80 left + 10 shared + 90 right = 180 unique trades
+        assert len(trades) == 180
+        # Verify no duplicate trade_ids
+        trade_ids = [t.trade_id for t in trades]
+        assert len(trade_ids) == len(set(trade_ids))
+
+    @patch("arcana.ingestion.coinbase.time_mod.sleep")
+    def test_recursive_subdivision_depth(self, mock_sleep):
+        """Can subdivide multiple levels deep for very busy periods."""
+        # Level 0: full → subdivide
+        full_0 = _make_raw_trades(DEFAULT_LIMIT, "2026-02-10T14:00:00Z", prefix="f0")
+        # Level 1 left: full → subdivide again
+        full_1_left = _make_raw_trades(DEFAULT_LIMIT, "2026-02-10T14:00:00Z", prefix="f1l")
+        # Level 1 right: under limit
+        partial_1_right = _make_raw_trades(100, "2026-02-10T14:30:00Z", prefix="p1r")
+        # Level 2 left-left: under limit
+        partial_2_ll = _make_raw_trades(120, "2026-02-10T14:00:00Z", prefix="p2ll")
+        # Level 2 left-right: under limit
+        partial_2_lr = _make_raw_trades(130, "2026-02-10T14:15:00Z", prefix="p2lr")
+
+        source = CoinbaseSource()
+        source._client = MagicMock()
+        source._client.get.side_effect = [
+            _mock_response({"trades": full_0}),        # depth=0: full window
+            _mock_response({"trades": full_1_left}),    # depth=1: left half
+            _mock_response({"trades": partial_2_ll}),   # depth=2: left-left quarter
+            _mock_response({"trades": partial_2_lr}),   # depth=2: left-right quarter
+            _mock_response({"trades": partial_1_right}),  # depth=1: right half
+        ]
+
+        start = datetime(2026, 2, 10, 14, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 2, 10, 15, 0, 0, tzinfo=timezone.utc)
+
+        trades = source.fetch_all_trades("ETH-USD", start, end)
+
+        assert source._client.get.call_count == 5
+        # All trades deduped and sorted
+        assert len(trades) == 350  # 120 + 130 + 100
+        for i in range(1, len(trades)):
+            assert trades[i].timestamp >= trades[i - 1].timestamp
+
+    @patch("arcana.ingestion.coinbase.time_mod.sleep")
+    def test_respects_max_depth(self, mock_sleep):
+        """Should stop subdividing at MAX_DEPTH and return what it has."""
+        # Always return exactly DEFAULT_LIMIT trades to force maximum recursion
+        always_full = _make_raw_trades(DEFAULT_LIMIT)
+
+        source = CoinbaseSource()
+        source._client = MagicMock()
+        source._client.get.return_value = _mock_response({"trades": always_full})
+
+        start = datetime(2026, 2, 10, 14, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 2, 10, 15, 0, 0, tzinfo=timezone.utc)
+
+        trades = source.fetch_all_trades("ETH-USD", start, end)
+
+        # Should not recurse forever — bounded by MAX_DEPTH (10)
+        # At depth 10: 2^10 = 1024 leaf calls + internal calls
+        # But with dedup all returning same trade_ids, result is just DEFAULT_LIMIT
+        assert len(trades) == DEFAULT_LIMIT
+        assert source._client.get.call_count > 1  # subdivision happened
+
+    @patch("arcana.ingestion.coinbase.time_mod.sleep")
+    def test_results_sorted_ascending(self, mock_sleep):
+        """Output from fetch_all_trades is always sorted ascending by timestamp."""
+        full_batch = _make_raw_trades(DEFAULT_LIMIT, "2026-02-10T14:00:00Z", prefix="full")
+        left = _make_raw_trades(50, "2026-02-10T14:00:00Z", prefix="left")
+        right = _make_raw_trades(60, "2026-02-10T14:30:00Z", prefix="right")
+
+        source = CoinbaseSource()
+        source._client = MagicMock()
+        source._client.get.side_effect = [
+            _mock_response({"trades": full_batch}),
+            _mock_response({"trades": left}),
+            _mock_response({"trades": right}),
+        ]
+
+        start = datetime(2026, 2, 10, 14, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 2, 10, 15, 0, 0, tzinfo=timezone.utc)
+
+        trades = source.fetch_all_trades("ETH-USD", start, end)
+
+        for i in range(1, len(trades)):
+            assert trades[i].timestamp >= trades[i - 1].timestamp

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -44,7 +44,7 @@ class TestIngestBackfill:
 
         source = MagicMock(spec=CoinbaseSource)
         source.name = "coinbase"
-        source.fetch_trades.return_value = trades
+        source.fetch_all_trades.return_value = trades
         source._client = True  # just needs to be truthy
 
         db = MagicMock()
@@ -56,7 +56,7 @@ class TestIngestBackfill:
 
         assert total == 10
         assert db.insert_trades.called
-        assert source.fetch_trades.called
+        assert source.fetch_all_trades.called
 
     @patch("arcana.pipeline.GracefulShutdown")
     @patch("arcana.pipeline.time_mod.sleep")
@@ -66,7 +66,7 @@ class TestIngestBackfill:
 
         source = MagicMock(spec=CoinbaseSource)
         source.name = "coinbase"
-        source.fetch_trades.return_value = []
+        source.fetch_all_trades.return_value = []
         source._client = True
 
         last = datetime(2026, 2, 10, 14, 0, 0, tzinfo=timezone.utc)
@@ -78,7 +78,7 @@ class TestIngestBackfill:
         ingest_backfill(source, db, "ETH-USD", since)
 
         # The first fetch_trades call should start from last, not since
-        first_call = source.fetch_trades.call_args_list[0]
+        first_call = source.fetch_all_trades.call_args_list[0]
         assert first_call.kwargs["start"] == last
 
     @patch("arcana.pipeline.GracefulShutdown")
@@ -92,7 +92,7 @@ class TestIngestBackfill:
 
         source = MagicMock(spec=CoinbaseSource)
         source.name = "coinbase"
-        source.fetch_trades.return_value = trades
+        source.fetch_all_trades.return_value = trades
         source._client = True
 
         db = MagicMock()
@@ -126,7 +126,7 @@ class TestIngestBackfill:
 
         source = MagicMock(spec=CoinbaseSource)
         source.name = "coinbase"
-        source.fetch_trades.side_effect = toggle_shutdown
+        source.fetch_all_trades.side_effect = toggle_shutdown
         source._client = True
 
         db = MagicMock()


### PR DESCRIPTION
…ngestion

The Coinbase API returns at most 300 trades per request. Busy hours with 2000+ trades were silently dropping ~85% of data, causing ~60-minute gaps at hour boundaries. This adds fetch_all_trades() which recursively splits time windows in half when the per-request limit is hit, ensuring all trades are captured regardless of trading volume.

