### PR TITLE
Fix unique constraint for TimescaleDB hypertable compatibility

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -341,7 +341,7 @@ CREATE TABLE raw_trades (
     price        NUMERIC       NOT NULL,
     size         NUMERIC       NOT NULL,
     side         TEXT          NOT NULL,    -- 'buy', 'sell', or 'unknown'
-    UNIQUE (source, trade_id)
+    UNIQUE (source, trade_id, timestamp)
 );
 
 SELECT create_hypertable('raw_trades', 'timestamp');

--- a/src/arcana/storage/database.py
+++ b/src/arcana/storage/database.py
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS raw_trades (
     price        NUMERIC       NOT NULL,
     size         NUMERIC       NOT NULL,
     side         TEXT          NOT NULL,
-    UNIQUE (source, trade_id)
+    UNIQUE (source, trade_id, timestamp)
 );
 
 CREATE INDEX IF NOT EXISTS idx_raw_trades_pair_ts
@@ -65,7 +65,7 @@ SELECT create_hypertable('bars', 'time_start', if_not_exists => TRUE);
 UPSERT_TRADES = """
 INSERT INTO raw_trades (timestamp, trade_id, source, pair, price, size, side)
 VALUES (%s, %s, %s, %s, %s, %s, %s)
-ON CONFLICT (source, trade_id) DO NOTHING;
+ON CONFLICT (source, trade_id, timestamp) DO NOTHING;
 """
 
 UPSERT_BARS = """


### PR DESCRIPTION
TimescaleDB requires the partitioning column (timestamp) to be part of any unique constraint on a hypertable. Changed UNIQUE (source, trade_id) to UNIQUE (source, trade_id, timestamp) and updated the upsert ON CONFLICT clause to match. This was causing workers to crash-loop in Docker with "cannot create a unique index without the column timestamp".
