### PR TITLE
Code audit: remove unused imports, fix stale PLAN.md references

### DIFF
--- a/src/arcana/cli.py
+++ b/src/arcana/cli.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 
 import click
 
-from arcana.config import ArcanaConfig, DatabaseConfig
+from arcana.config import DatabaseConfig
 from arcana.ingestion.coinbase import CoinbaseSource
 from arcana.pipeline import DAEMON_INTERVAL, ingest_backfill, run_daemon
 from arcana.storage.database import Database
@@ -361,7 +361,6 @@ def swarm_status(
                 rows = cur.fetchall()
 
             total = db_conn.get_trade_count(pair)
-            first_ts = db_conn.get_last_timestamp(pair)  # will use for coverage
 
             click.echo(f"Swarm status: {pair}")
             click.echo(f"  Total trades: {total:,}")

--- a/src/arcana/storage/database.py
+++ b/src/arcana/storage/database.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 import psycopg
-from psycopg.rows import dict_row
 
 from arcana.config import DatabaseConfig
 from arcana.ingestion.models import Trade

--- a/src/arcana/swarm.py
+++ b/src/arcana/swarm.py
@@ -7,7 +7,6 @@ overlapping boundaries and restarts are safe.
 """
 
 import logging
-import math
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 


### PR DESCRIPTION
Code cleanup:
- Remove unused import: math (swarm.py)
- Remove unused import: ArcanaConfig (cli.py)
- Remove unused import: dict_row (database.py)
- Remove dead variable: first_ts in swarm_status (cli.py)

PLAN.md sync (9 fixes):
- Trade schema: side includes "unknown"
- CLI examples: arcana ingest ETH-USD (not coinbase ETH-USD)
- Remove nonexistent "arcana db status" command
- O(N/300) → O(N/1000) for updated DEFAULT_LIMIT
- UNIQUE constraint updated to include timestamp (3 locations)
- --until flag documented as implemented (was listed as future)
- Remove pre-commit from dev deps (not in pyproject.toml)
- Update line counts and test counts to match actual code
- standard bar tests: 21 (not 22)